### PR TITLE
fix: OSMの帰属が見えない問題を解消

### DIFF
--- a/static/map.css
+++ b/static/map.css
@@ -5,7 +5,7 @@
 
 #map {
   width: 100vw;
-  height: 100vh;
+  height: 92vh;
 }
 
 .line {


### PR DESCRIPTION
## やったこと

- /map/で地図にOSMの帰属が見えない問題を解消